### PR TITLE
Update pulseaudio_backend.c

### DIFF
--- a/src/common/backend/pulseaudio_backend.c
+++ b/src/common/backend/pulseaudio_backend.c
@@ -96,7 +96,7 @@ int pulseaudio_open(audio_backend_handle_t handle, char const* device_name, enum
 
 /*    pulseaudio_backend->pulseaudio_handle = pa_simple_new(0, "vban", (direction == AUDIO_OUT) ? PA_STREAM_PLAYBACK : PA_STREAM_RECORD, (device_name[0] == '\0') ? 0 : device_name,
         (direction == AUDIO_OUT) ? "playback": "record", &ss, 0, (direction == AUDIO_OUT) ? &ba : 0, &ret);//*/
-    pulseaudio_backend->pulseaudio_handle = pa_simple_new(0, "vban", (direction == AUDIO_OUT) ? PA_STREAM_PLAYBACK : PA_STREAM_RECORD, (device_name[0] == '\0') ? 0 : device_name,
+    pulseaudio_backend->pulseaudio_handle = pa_simple_new(0, description, (direction == AUDIO_OUT) ? PA_STREAM_PLAYBACK : PA_STREAM_RECORD, (device_name[0] == '\0') ? 0 : device_name,
         (direction == AUDIO_OUT) ? "playback": "record", &ss, 0, (direction == AUDIO_OUT) ? &ba : 0, &ret);
     if (pulseaudio_backend->pulseaudio_handle == 0)
     {


### PR DESCRIPTION
default multiple vban devices will create multiple "vban" devices that are impossible to differenciate.
so we can also not auto wire more than once device.
this change allows to use the description tag as device name and auto rewire scripts (like for pulse-pipewire) will work now with multiple vbans running